### PR TITLE
Port 'fancy' plugin to webkit2gtk-4.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1147,7 +1147,7 @@ AC_SUBST(EXPAT_CFLAGS)
 AC_SUBST(EXPAT_LIBS)
 
 dnl webkit *********************************************************************
-PKG_CHECK_MODULES(WEBKIT, webkit-1.0 >= 1.1.14, HAVE_WEBKIT=yes, HAVE_WEBKIT=no)
+PKG_CHECK_MODULES(WEBKIT, webkit2gtk-4.0 >= 2.18.0, HAVE_WEBKIT=yes, HAVE_WEBKIT=no)
 AC_SUBST(WEBKIT_LIBS)
 AC_SUBST(WEBKIT_CFLAGS)
 
@@ -1502,7 +1502,7 @@ if test x"$enable_fancy_plugin" != xno; then
 	dependencies_missing=""
 
 	if test x"$HAVE_WEBKIT" = xno; then
-		dependencies_missing="libwebkit-1.0 $dependencies_missing"
+		dependencies_missing="libwebkit2gtk-4.0 $dependencies_missing"
 	fi
 	if test x"$HAVE_CURL" = xno; then
 		dependencies_missing="libcurl $dependencies_missing"

--- a/src/gtk/gtkutils.h
+++ b/src/gtk/gtkutils.h
@@ -240,13 +240,15 @@ gboolean auto_configure_service_sync(const gchar *service, const gchar *domain, 
 
 
 #if GTK_CHECK_VERSION (3, 2, 0)
+#if !GTK_CHECK_VERSION(3,22,25)
 #define GTK_TYPE_VBOX GTK_TYPE_BOX
+#define GTK_TYPE_HBOX GTK_TYPE_BOX
+#endif
 #define GtkVBox GtkBox
 #define GtkVBoxClass GtkBoxClass
 #define gtk_vbox_new(hmg,spc) g_object_new (GTK_TYPE_BOX, \
     "homogeneous", hmg, "spacing", spc, \
     "orientation", GTK_ORIENTATION_VERTICAL, NULL)
-#define GTK_TYPE_HBOX GTK_TYPE_BOX
 #define GtkHBox GtkBox
 #define GtkHBoxClass GtkBoxClass
 #define gtk_hbox_new(hmg,spc) g_object_new (GTK_TYPE_BOX, \

--- a/src/plugins/fancy/fancy_prefs.h
+++ b/src/plugins/fancy/fancy_prefs.h
@@ -21,12 +21,12 @@
 #define FANCY_PREFS_H
 
 #include <glib.h>
-#include <webkit/webkitwebsettings.h>
+#include <webkit2/webkit2.h>
 typedef struct _FancyPrefs FancyPrefs;
 
 struct _FancyPrefs
 	{
-	WebKitWebSettings *web_settings;
+	WebKitSettings *web_settings;
 
 	gboolean enable_images;
 	gboolean enable_remote_content;

--- a/src/plugins/fancy/fancy_viewer.h
+++ b/src/plugins/fancy/fancy_viewer.h
@@ -29,15 +29,8 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
-#include <webkit/webkitwebview.h>
-#include <webkit/webkitversion.h>
-#include <webkit/webkitwebframe.h>
-#include <webkit/webkitnetworkrequest.h>
-#include <webkit/webkitwebnavigationaction.h>
-#include <webkit/webkitwebpolicydecision.h>
-#if WEBKIT_CHECK_VERSION (1,3,10)
-#include <webkit/webkitglobals.h>
-#endif
+#include <webkit2/webkit2.h>
+#include <webkitdom/webkitdom.h>
 #include <prefs_common.h>
 #include "common/claws.h"
 #include "common/version.h"
@@ -99,7 +92,7 @@ struct _FancyViewer
 	GtkWidget         *stylesheet;
 
 	GtkWidget         *progress;
-	WebKitWebSettings *settings;
+	WebKitSettings    *settings;
 	gboolean          printing;
 	gboolean          override_prefs_images;
 	gboolean          override_prefs_remote_content;


### PR DESCRIPTION
Just for the purpose of viewing the changeset.

- [ ] Remaining deprecated names to update:
  - [ ] `webkit_web_frame_print_full`
  - [ ] `webkit_web_view_get_dom_document`
  - [ ] `webkit_web_view_search_text`
  - [ ] `gtk_menu_popup`
  - [ ] `WebKitLoadStatus`, `webkit_web_view_get_load_status`, ` webkit_web_view_get_progress`
  - [ ] `webkit_web_view_has_selection`
  - [ ] `webkit_web_view_get_hit_test_result`
  - [ ] `webkit_get_default_session`
  - [ ] `GTK_STOCK_CANCEL`
- [ ] Test functionality.